### PR TITLE
Prevent martingale from returning nan in certain situations by restricting what is sent to `integral_from_roots`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,138 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Added by Ian
+# omit DS_Store
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Code/assertion_audit_utils.py
+++ b/Code/assertion_audit_utils.py
@@ -1872,6 +1872,24 @@ def test_kaplan_martingale():
     s = [0.6,0.8,1.0,1.2,1.4]
     np.testing.assert_array_less(TestNonnegMean.kaplan_martingale(s, N=100000, t=0, random_order = True)[:1],[eps])
 
+    s1 = [1, 0, 1, 1, 0, 0, 1]
+    kmart1 = TestNonnegMean.kaplan_martingale(s1,
+                                              N=7,
+                                              t=3/7,
+                                              random_order=True)
+    # No nans introduced
+    assert(not any(np.isnan(kmart1[1])))
+
+    s2 = [1, 0, 1, 1, 0, 0, 0]
+    kmart2 = TestNonnegMean.kaplan_martingale(s2,
+                                              N=7,
+                                              t=3/7,
+                                              random_order=True)
+    # Since s1 and s2 only differ in the last observation,
+    # the resulting martingales should be identical up to the second
+    # last entry.
+    assert(all(kmart2[1][1:len(kmart2)] == kmart1[1][1:len(kmart1)]))
+
 def test_assorter_mean():
     pass # [FIX ME]
 

--- a/Code/assertion_audit_utils.py
+++ b/Code/assertion_audit_utils.py
@@ -1043,9 +1043,9 @@ class TestNonnegMean:
         jtilde = 1 - np.array(list(range(len(x))))/N
         # The term being mutliplied by gamma in the SHANGRLA paper
         c = x * jtilde / t_minus_Stilde - 1
-        # as a convention, 0/0 is 0 here. This prevents c from
-        # having nans.
-        c[np.logical_and(x == 0, t_minus_Stilde == 0)] = -1
+        # as a convention, 0/0 is 1 here. This prevents c from
+        # having nans and ensures the martingale property
+        c[np.logical_and(x == 0, t_minus_Stilde == 0)] = 0 
         c_nonzero = c[c != 0]
         # integral should not contain c_j if c_j = 0
         r = -np.array(1/c_nonzero) # roots

--- a/Code/assertion_audit_utils.py
+++ b/Code/assertion_audit_utils.py
@@ -1876,19 +1876,20 @@ def test_kaplan_martingale():
     kmart1 = TestNonnegMean.kaplan_martingale(s1,
                                               N=7,
                                               t=3/7,
-                                              random_order=True)
+                                              random_order=True)[1]
     # No nans introduced
-    assert(not any(np.isnan(kmart1[1])))
+    assert(not any(np.isnan(kmart1)))
 
     s2 = [1, 0, 1, 1, 0, 0, 0]
     kmart2 = TestNonnegMean.kaplan_martingale(s2,
                                               N=7,
                                               t=3/7,
-                                              random_order=True)
+                                              random_order=True)[1]
     # Since s1 and s2 only differ in the last observation,
     # the resulting martingales should be identical up to the second
     # last entry.
-    assert(all(kmart2[1][1:len(kmart2)] == kmart1[1][1:len(kmart1)]))
+    assert(all(np.equal(kmart2[0:(len(kmart2)-1)],
+                        kmart1[0:(len(kmart1)-1)])))
 
 def test_assorter_mean():
     pass # [FIX ME]


### PR DESCRIPTION
* Changed the way `integral_from_roots` is called as to match what is written in the [MartInf](https://github.com/pbstark/MartInf/blob/master/kmart.ipynb) repository
* Uses the convention of $X / t_minus_Stilde = 0$ when $X$ and $t_minus_Stilde$ are both 0. 
* Also added some test cases corresponding to issue #4 
* Added a gitignore since I used virtual environments, and didn't want them to get committed. Feel free to discard that