### PR TITLE
Fix minor bug in the Assertion class

### DIFF
--- a/Code/assertion_audit_utils.py
+++ b/Code/assertion_audit_utils.py
@@ -56,7 +56,7 @@ class Assertion:
         
     def __str__(self):
         return (f'contest: {self.contest} margin: {self.margin} p-value: {self.p_value}'
-                f'p-history length: {len(p_history)} proved: {self.proved}'
+                f'p-history length: {len(self.p_history)} proved: {self.proved}'
                )
 
     def set_assorter(self, assorter):


### PR DESCRIPTION
This fixes a bug in the `__str__` method of the `Assertion` class: it was missing a `self.` for the `p_history`.