### PR TITLE
BUG: start with prefix=False for sample size calculations

### DIFF
--- a/shangrla/shangrla/Audit.py
+++ b/shangrla/shangrla/Audit.py
@@ -762,7 +762,7 @@ class Audit:
                 if not asn.proved:
                     if mvr_sample is not None: # use MVRs to estimate the next sample size
                         data, u =  asn.mvrs_to_data(mvr_sample, cvr_sample)
-                        new_size = max(new_size, asn.find_sample_size(data=data, 
+                        new_size = max(new_size, asn.find_sample_size(data=data, prefix=True,
                                                                   reps=self.reps, quantile=self.quantile,
                                                                   seed=self.sim_seed))
                     else:
@@ -1212,7 +1212,7 @@ class Assertion:
         
         
     def find_sample_size(
-                    self, data: np.array=None, prefix: bool=True, rate_1: float=None, rate_2: float=None,
+                    self, data: np.array=None, prefix: bool=False, rate_1: float=None, rate_2: float=None,
                     reps: int=None, quantile: float=0.5, seed: int=1234567890) -> int:
         '''
         Estimate sample size needed to reject the null hypothesis that the assorter mean is <=1/2,

--- a/shangrla/shangrla/NonnegMean.py
+++ b/shangrla/shangrla/NonnegMean.py
@@ -109,7 +109,7 @@ class NonnegMean:
         j = np.arange(1,len(x)+1)              # 1, 2, 3, ..., len(x)
         m = (N*t-S)/(N-j+1) if np.isfinite(N) else t   # mean of population after (j-1)st draw, if null is true
         x = np.array(x)
-        with np.errstate(divide='ignore',invalid='ignore'):
+        with np.errstate(divide='ignore', invalid='ignore', over='ignore'):
             etaj = self.estim(x)
             terms = np.cumprod((x*etaj/m + (u-x)*(u-etaj)/(u-m))/u)
         terms[m>u] = 0                                       # true mean is certainly less than hypothesized
@@ -161,7 +161,7 @@ class NonnegMean:
         j = np.arange(1,len(x)+1)              # 1, 2, 3, ..., len(x)
         m = (N*t-S)/(N-j+1) if np.isfinite(N) else t   # mean of population after (j-1)st draw, if null is true
         x = np.array(x)
-        with np.errstate(divide='ignore',invalid='ignore'):
+        with np.errstate(divide='ignore', invalid='ignore', over='ignore'):
             lam = self.bet(x)
             terms = np.cumprod(1+lam*(x-m))
         terms[m>u] = 0                                       # true mean is certainly less than hypothesized
@@ -473,7 +473,7 @@ class NonnegMean:
         S = np.insert(np.cumsum(x+g),0,0)[0:-1]  # 0, x_1, x_1+x_2, ...,
         j = np.arange(1,len(x)+1)                # 1, 2, 3, ..., len(x)
         m = (N*(t+g)-S)/(N-j+1) if np.isfinite(N) else t+g   # mean of population after (j-1)st draw, if null is true
-        with np.errstate(divide='ignore',invalid='ignore'):
+        with np.errstate(divide='ignore', invalid='ignore', over='ignore'):
             terms = np.cumprod((x+g)/m)
         terms[m<0] = np.inf
         p = min((1/np.max(terms) if random_order else 1/terms[-1]),1)
@@ -612,7 +612,7 @@ class NonnegMean:
         else:
             m = t
             etas = eta
-        with np.errstate(divide='ignore',invalid='ignore'):
+        with np.errstate(divide='ignore', invalid='ignore', over='ignore'):
             terms = np.cumprod((x*etas/m + (u-x)*(u-etas)/(u-m))/u) # generalization of Bernoulli SPRT
         terms[m<0] = np.inf                        # the null is surely false
         terms = np.cumprod(terms)


### PR DESCRIPTION
updated default value of `prefix` to `False` in sample size calculations, so that initial sample size does simulations.

Set `prefix=True` when there are MVRs in the call to audit.find_sample_size()