### PR TITLE
add class function Contest.tally()

### DIFF
--- a/shangrla/shangrla/Audit.py
+++ b/shangrla/shangrla/Audit.py
@@ -2013,6 +2013,42 @@ class Contest:
 
 
     @classmethod
+    def tally(cls, con_list: list=None, cvr_list: list=None) -> dict:
+        '''
+        Tally the votes in the contests in con_list from a list of CVRs.
+        Only tallies plurality, multi-winner plurality, supermajority, and approval contests
+
+        Parameters
+        ----------
+        con_list: list of Contest objects to find tallies for
+        cvr_list: list of CVRs containing the votes to tally
+
+        Returns
+        -------
+
+        Side Effects
+        ------------
+        Sets the `tally` dict for the contests in con_list, if their social choice function is appropriate
+        '''
+        tallies = {}
+        cons = []
+        for c in con_list:
+            if c.choice_function in [Contest.SOCIAL_CHOICE_FUNCTION.PLURALITY,
+                                     Contest.SOCIAL_CHOICE_FUNCTION.SUPERMAJORITY,
+                                     Contest.SOCIAL_CHOICE_FUNCTION.APPROVAL]:
+                cons.append(c)
+                c.tally = defaultdict(int)
+            else:
+                warnings.warn(f'contest {c.id} ({c.name}) has social choice function {c.choice_function}: not tabulated')
+        for cvr in cvr_list:
+            for c in con_list:
+                for candidate, vote in c.votes[c.id].items():
+                    if candidate:
+                        c.tally[candidate] += int(bool(vote))
+
+
+    
+    @classmethod
     def from_dict(cls, d: dict) -> dict:
         '''
         define a contest objects from a dict containing data for one contest

--- a/shangrla/shangrla/Audit.py
+++ b/shangrla/shangrla/Audit.py
@@ -2037,14 +2037,16 @@ class Contest:
                                      Contest.SOCIAL_CHOICE_FUNCTION.SUPERMAJORITY,
                                      Contest.SOCIAL_CHOICE_FUNCTION.APPROVAL]:
                 cons.append(c)
-                con.tally = defaultdict(int)
+                c.tally = defaultdict(int)
             else:
-                warnings.warn(f'contest {c.id} ({c.name}) has social choice function {c.choice_function}: not tabulated')
+                warnings.warn(f'contest {c.id} ({c.name}) has social choice function ' +
+                              f'{c.choice_function}: not tabulated')
         for cvr in cvr_list:
-            for c in con_list:
-                for candidate, vote in c.votes[c.id].items():
-                    if candidate:
-                        c.tally[candidate] += int(bool(vote))
+            for c in cons:
+                if cvr.has_contest(c.id):
+                    for candidate, vote in cvr.votes[c.id].items():
+                        if candidate:
+                            c.tally[candidate] += int(bool(vote))
 
 
     

--- a/shangrla/shangrla/Audit.py
+++ b/shangrla/shangrla/Audit.py
@@ -2013,14 +2013,14 @@ class Contest:
 
 
     @classmethod
-    def tally(cls, con_list: list=None, cvr_list: list=None) -> dict:
+    def tally(cls, con_dict: dict=None, cvr_list: list=None) -> dict:
         '''
         Tally the votes in the contests in con_list from a list of CVRs.
         Only tallies plurality, multi-winner plurality, supermajority, and approval contests
 
         Parameters
         ----------
-        con_list: list of Contest objects to find tallies for
+        con_dict: list of Contest objects to find tallies for
         cvr_list: list of CVRs containing the votes to tally
 
         Returns
@@ -2032,12 +2032,12 @@ class Contest:
         '''
         tallies = {}
         cons = []
-        for c in con_list:
+        for id, c in con_dict.items():
             if c.choice_function in [Contest.SOCIAL_CHOICE_FUNCTION.PLURALITY,
                                      Contest.SOCIAL_CHOICE_FUNCTION.SUPERMAJORITY,
                                      Contest.SOCIAL_CHOICE_FUNCTION.APPROVAL]:
                 cons.append(c)
-                c.tally = defaultdict(int)
+                con.tally = defaultdict(int)
             else:
                 warnings.warn(f'contest {c.id} ({c.name}) has social choice function {c.choice_function}: not tabulated')
         for cvr in cvr_list:

--- a/shangrla/shangrla/tests/test_Contests.py
+++ b/shangrla/shangrla/tests/test_Contests.py
@@ -75,7 +75,7 @@ class TestContests:
             assert c.__dict__.get('id') == id
             for att in atts:
                 if att != 'id':
-                    assert c.__dict__.get(att) == contest_dict[id].get(att)
+                    assert c.__dict__.get(att) == self.contest_dict[id].get(att)
 
     def test_tally(self):
         cvr_dict = [{'id': 1, 'votes': {'AvB': {'Alice':True}, 'CvD': {'Candy':True}}},

--- a/shangrla/shangrla/tests/test_Contests.py
+++ b/shangrla/shangrla/tests/test_Contests.py
@@ -24,19 +24,8 @@ from shangrla.Hart import Hart
 ###################################################################################################
 class TestContests:
 
-    def test_contests_from_dict_of_dicts(self):
-        ids = ['1','2']
-        choice_functions = [Contest.SOCIAL_CHOICE_FUNCTION.PLURALITY, Contest.SOCIAL_CHOICE_FUNCTION.SUPERMAJORITY]
-        risk_limit = 0.05
-        cards = [10000, 20000]
-        n_winners = [2, 1]
-        candidates = [4, 2]
-        audit_type = [Audit.AUDIT_TYPE.POLLING, Audit.AUDIT_TYPE.CARD_COMPARISON]
-        use_style = True
-        atts = ('id','name','risk_limit','cards','choice_function','n_winners','share_to_win','candidates',
-                'winner','assertion_file','audit_type','test','use_style')
-        contest_dict = {
-                 'con_1': {
+    contest_dict = {
+                 'AvB': {
                  'name': 'contest_1',
                  'risk_limit': 0.05,
                  'cards': 10**4,
@@ -49,26 +38,61 @@ class TestContests:
                  'test': NonnegMean.alpha_mart,
                  'use_style': True
                 },
-                 'con_2': {
+                 'CvD': {
                  'name': 'contest_2',
                  'risk_limit': 0.05,
                  'cards': 10**4,
                  'choice_function': Contest.SOCIAL_CHOICE_FUNCTION.SUPERMAJORITY,
                  'n_winners': 1,
                  'candidates': 4,
-                 'candidates': ['alice','bob','carol','dave',],
+                 'candidates': ['alice','bob','carol','dave'],
                  'winner': ['alice'],
                  'audit_type': Audit.AUDIT_TYPE.POLLING,
                  'test': NonnegMean.alpha_mart,
                  'use_style': False
                 }
+                 'EvF': {
+                 'name': 'contest_3',
+                 'risk_limit': 0.05,
+                 'cards': 10**4,
+                 'choice_function': Contest.SOCIAL_CHOICE_FUNCTION.IRV,
+                 'n_winners': 1,
+                 'candidates': 4,
+                 'candidates': ['alice','bob','carol','dave'],
+                 'winner': ['alice'],
+                 'audit_type': Audit.AUDIT_TYPE.CARD_COMPARISON,
+                 'test': NonnegMean.alpha_mart,
+                 'use_style': False
                 }
+            }
+
+    def test_contests_from_dict_of_dicts(self):
+        ids = ['1','2']
+        atts = ('id','name','risk_limit','cards','choice_function','n_winners','share_to_win','candidates',
+                'winner','assertion_file','audit_type','test','use_style')
         contests = Contest.from_dict_of_dicts(contest_dict)
-        for i, c in contests.items():
-            assert c.__dict__.get('id') == i
+        for id, c in contests.items():
+            assert c.__dict__.get('id') == id
             for att in atts:
                 if att != 'id':
-                    assert c.__dict__.get(att) == contest_dict[i].get(att)
+                    assert c.__dict__.get(att) == contest_dict[id].get(att)
+
+    def test_tally(self):
+        cvr_dict = [{'id': 1, 'votes': {'AvB': {'Alice':True}, 'CvD': {'Candy':True}}},
+                    {'id': 2, 'votes': {'AvB': {'Bob':True}, 'CvD': {'Elvis':True, 'Candy':False}}},
+                    {'id': 3, 'votes': {'EvF': {'Bob':1, 'Edie':2}, 'CvD': {'Elvis':False, 'Candy':True}}},
+                    {'id': 4, 'votes': {'AvB': {'Alice':1}, 'CvD': {'Candy':'yes'}}},
+                    {'id': 5, 'votes': {'AvB': {'Bob':True}, 'CvD': {'Elvis':True, 'Candy':False}}},
+                    {'id': 6, 'votes': {'EvF': {'Bob':2, 'Edie':1}, 'CvD': {'Elvis':False, 'Candy':True}}},
+                    {'id': 7, 'votes': {'AvB': {'Alice':2}, 'CvD': {'Elvis':False, 'Candy':True}}}
+                   ]
+        cvr_list = CVR.from_dict(cvr_dict)
+        tally(contests)
+        assert contests['AvB'].tally == {'Alice': 3, 'Bob': 3}
+        assert contests['CvD'].tally == {'Candy': 5, 'Elvis': 2}
+        assert contests['EvF'].tally is None 
+        # TO DO: assert that this raises a warning about contest EvF
+            
 
 ##########################################################################################
 if __name__ == "__main__":

--- a/shangrla/shangrla/tests/test_Contests.py
+++ b/shangrla/shangrla/tests/test_Contests.py
@@ -26,6 +26,7 @@ class TestContests:
 
     contest_dict = {
                  'AvB': {
+                 'id': 'AvB',
                  'name': 'contest_1',
                  'risk_limit': 0.05,
                  'cards': 10**4,
@@ -39,6 +40,7 @@ class TestContests:
                  'use_style': True
                 },
                  'CvD': {
+                 'id': 'CvD',
                  'name': 'contest_2',
                  'risk_limit': 0.05,
                  'cards': 10**4,
@@ -52,6 +54,7 @@ class TestContests:
                  'use_style': False
                 },
                  'EvF': {
+                 'id': 'EvF',
                  'name': 'contest_3',
                  'risk_limit': 0.05,
                  'cards': 10**4,
@@ -67,7 +70,6 @@ class TestContests:
             }
 
     def test_contests_from_dict_of_dicts(self):
-        ids = ['1','2']
         atts = ('id','name','risk_limit','cards','choice_function','n_winners','share_to_win','candidates',
                 'winner','assertion_file','audit_type','test','use_style')
         contests = Contest.from_dict_of_dicts(self.contest_dict)
@@ -88,8 +90,9 @@ class TestContests:
                    ]
         cvr_list = CVR.from_dict(cvr_dict)
         contests = Contest.from_dict_of_dicts(self.contest_dict)
+        print(contests)
         Contest.tally(contests, cvr_list)
-        assert contests['AvB'].tally == {'Alice': 3, 'Bob': 3}
+        assert contests['AvB'].tally == {'Alice': 3, 'Bob': 2}
         assert contests['CvD'].tally == {'Candy': 5, 'Elvis': 2}
         assert contests['EvF'].tally is None 
         # TO DO: assert that this raises a warning about contest EvF

--- a/shangrla/shangrla/tests/test_Contests.py
+++ b/shangrla/shangrla/tests/test_Contests.py
@@ -70,7 +70,7 @@ class TestContests:
         ids = ['1','2']
         atts = ('id','name','risk_limit','cards','choice_function','n_winners','share_to_win','candidates',
                 'winner','assertion_file','audit_type','test','use_style')
-        contests = Contest.from_dict_of_dicts(contest_dict)
+        contests = Contest.from_dict_of_dicts(self.contest_dict)
         for id, c in contests.items():
             assert c.__dict__.get('id') == id
             for att in atts:
@@ -87,6 +87,7 @@ class TestContests:
                     {'id': 7, 'votes': {'AvB': {'Alice':2}, 'CvD': {'Elvis':False, 'Candy':True}}}
                    ]
         cvr_list = CVR.from_dict(cvr_dict)
+        contests = Contest.from_dict_of_dicts(self.contest_dict)
         Contest.tally(contests, cvr_list)
         assert contests['AvB'].tally == {'Alice': 3, 'Bob': 3}
         assert contests['CvD'].tally == {'Candy': 5, 'Elvis': 2}

--- a/shangrla/shangrla/tests/test_Contests.py
+++ b/shangrla/shangrla/tests/test_Contests.py
@@ -50,7 +50,7 @@ class TestContests:
                  'audit_type': Audit.AUDIT_TYPE.POLLING,
                  'test': NonnegMean.alpha_mart,
                  'use_style': False
-                }
+                },
                  'EvF': {
                  'name': 'contest_3',
                  'risk_limit': 0.05,

--- a/shangrla/shangrla/tests/test_Contests.py
+++ b/shangrla/shangrla/tests/test_Contests.py
@@ -87,7 +87,7 @@ class TestContests:
                     {'id': 7, 'votes': {'AvB': {'Alice':2}, 'CvD': {'Elvis':False, 'Candy':True}}}
                    ]
         cvr_list = CVR.from_dict(cvr_dict)
-        tally(contests)
+        Contest.tally(contests, cvr_list)
         assert contests['AvB'].tally == {'Alice': 3, 'Bob': 3}
         assert contests['CvD'].tally == {'Candy': 5, 'Elvis': 2}
         assert contests['EvF'].tally is None 


### PR DESCRIPTION
 tabulate candidate subtotals from CVRs for a dict of contests and updates their `tally` dicts. Ignores contests with social choice functions other than plurality, supermajority, and approval.