### PR TITLE
Support Newer Dominion CVR Format and add Group Selection

### DIFF
--- a/shangrla/shangrla/tests/Data/Dominion_CVRs/CVR_Export/CvrExport_0.json
+++ b/shangrla/shangrla/tests/Data/Dominion_CVRs/CVR_Export/CvrExport_0.json
@@ -1,0 +1,50 @@
+{
+    "Version": "5.10.50.85",
+    "ElectionId": "GENERAL ELECTION",
+    "Sessions": [
+        {
+            "TabulatorId": 1,
+            "BatchId": 2,
+            "RecordId": 13,
+            "CountingGroupId": 2,
+            "ImageMask": "D:\\NAS\\GENERAL ELECTION\\Results\\Tabulator01\\Batch002\\Images\\00001_00002_000013*.*",
+            "SessionType": "ScannedVote",
+            "VotingSessionIdentifier": "",
+            "UniqueVotingIdentifier": "",
+            "Original": {
+                "PrecinctPortionId": 23,
+                "BallotTypeId": 3,
+                "IsCurrent": true,
+                "Cards": [
+                    {
+                        "Id": 12345,
+                        "KeyInId": 12345,
+                        "PaperIndex": 0,
+                        "Contests": [
+                            {
+                                "Id": 1,
+                                "ManifestationId": 123456,
+                                "Undervotes": 0,
+                                "Overvotes": 0,
+                                "OutstackConditionIds": [],
+                                "Marks": [
+                                    {
+                                        "CandidateId": 5,
+                                        "ManifestationId": 654321,
+                                        "PartyId": 1,
+                                        "Rank": 1,
+                                        "MarkDensity": 83,
+                                        "IsAmbiguous": false,
+                                        "IsVote": true,
+                                        "OutstackConditionIds": []
+                                    }
+                                ]
+                            }
+                        ],
+                        "OutstackConditionIds": []
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/shangrla/shangrla/tests/Data/Dominion_CVRs/CVR_Export/CvrExport_1.json
+++ b/shangrla/shangrla/tests/Data/Dominion_CVRs/CVR_Export/CvrExport_1.json
@@ -1,0 +1,79 @@
+{
+    "Version": "5.10.50.85",
+    "ElectionId": "GENERAL ELECTION",
+    "Sessions": [
+        {
+            "TabulatorId": 1,
+            "BatchId": 5,
+            "RecordId": "X",
+            "CountingGroupId": 2,
+            "ImageMask": "D:\\NAS\\GENERAL ELECTION\\Results\\Tabulator01\\Batch002\\Images\\00001_00005_000119*.*",
+            "SessionType": "ScannedVote",
+            "VotingSessionIdentifier": "",
+            "UniqueVotingIdentifier": "",
+            "Original": {
+                "PrecinctPortionId": 23,
+                "BallotTypeId": 4,
+                "IsCurrent": false,
+                "Cards": [
+                    {
+                        "Id": 23456,
+                        "KeyInId": 23456,
+                        "PaperIndex": 1,
+                        "Contests": [
+                            {
+                                "Id": 1,
+                                "ManifestationId": 234567,
+                                "Undervotes": 0,
+                                "Overvotes": 0,
+                                "OutstackConditionIds": [],
+                                "Marks": [
+                                    {
+                                        "CandidateId": 6,
+                                        "ManifestationId": 765432,
+                                        "Rank": 1,
+                                        "WriteinIndex": 0,
+                                        "MarkDensity": 99,
+                                        "WriteinDensity": 100,
+                                        "IsAmbiguous": false,
+                                        "IsVote": true,
+                                        "OutstackConditionIds": [
+                                            1
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "OutstackConditionIds": []
+                    }
+                ]
+            },
+            "Modified": {
+                "PrecinctPortionId": 214,
+                "BallotTypeId": 102,
+                "IsCurrent": true,
+                "Cards": [
+                    {
+                        "Id": 23456,
+                        "KeyInId": 23456,
+                        "PaperIndex": 1,
+                        "Contests": [
+                            {
+                                "Id": 1,
+                                "ManifestationId": 234567,
+                                "Undervotes": 1,
+                                "Overvotes": 0,
+                                "OutstackConditionIds": [
+                                    4,
+                                    6
+                                ],
+                                "Marks": []
+                            }
+                        ],
+                        "OutstackConditionIds": []
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/shangrla/shangrla/tests/Data/Dominion_CVRs/CVR_Export/README.txt
+++ b/shangrla/shangrla/tests/Data/Dominion_CVRs/CVR_Export/README.txt
@@ -1,0 +1,2 @@
+These two files, if recombined, contain the same data contained in ../test_5.10.50.85.Dominion.json.
+The filenames match the naming scheme of the exported data from the voting system.

--- a/shangrla/shangrla/tests/Data/Dominion_CVRs/test_5.10.50.85.Dominion.json
+++ b/shangrla/shangrla/tests/Data/Dominion_CVRs/test_5.10.50.85.Dominion.json
@@ -1,0 +1,123 @@
+{
+    "Version": "5.10.50.85",
+    "ElectionId": "GENERAL ELECTION",
+    "Sessions": [
+        {
+            "TabulatorId": 1,
+            "BatchId": 2,
+            "RecordId": 13,
+            "CountingGroupId": 1,
+            "ImageMask": "D:\\GENERAL ELECTION\\Results\\Tabulator01\\Batch002\\Images\\00001_00002_000013*.*",
+            "SessionType": "ScannedVote",
+            "VotingSessionIdentifier": "",
+            "UniqueVotingIdentifier": "",
+            "Original": {
+                "PrecinctPortionId": 23,
+                "BallotTypeId": 3,
+                "IsCurrent": true,
+                "Cards": [
+                    {
+                        "Id": 12345,
+                        "KeyInId": 12345,
+                        "PaperIndex": 0,
+                        "Contests": [
+                            {
+                                "Id": 1,
+                                "ManifestationId": 123456,
+                                "Undervotes": 0,
+                                "Overvotes": 0,
+                                "OutstackConditionIds": [],
+                                "Marks": [
+                                    {
+                                        "CandidateId": 5,
+                                        "ManifestationId": 654321,
+                                        "PartyId": 1,
+                                        "Rank": 1,
+                                        "MarkDensity": 83,
+                                        "IsAmbiguous": false,
+                                        "IsVote": true,
+                                        "OutstackConditionIds": []
+                                    }
+                                ]
+                            }
+                        ],
+                        "OutstackConditionIds": []
+                    }
+                ]
+            }
+        },
+        {
+            "TabulatorId": 1,
+            "BatchId": 5,
+            "RecordId": "X",
+            "CountingGroupId": 2,
+            "ImageMask": "D:\\GENERAL ELECTION\\Results\\Tabulator01\\Batch005\\Images\\00001_00005_000119*.*",
+            "SessionType": "ScannedVote",
+            "VotingSessionIdentifier": "",
+            "UniqueVotingIdentifier": "",
+            "Original": {
+                "PrecinctPortionId": 23,
+                "BallotTypeId": 4,
+                "IsCurrent": false,
+                "Cards": [
+                    {
+                        "Id": 23456,
+                        "KeyInId": 23456,
+                        "PaperIndex": 1,
+                        "Contests": [
+                            {
+                                "Id": 1,
+                                "ManifestationId": 234567,
+                                "Undervotes": 0,
+                                "Overvotes": 0,
+                                "OutstackConditionIds": [],
+                                "Marks": [
+                                    {
+                                        "CandidateId": 6,
+                                        "ManifestationId": 765432,
+                                        "Rank": 1,
+                                        "WriteinIndex": 0,
+                                        "MarkDensity": 99,
+                                        "WriteinDensity": 100,
+                                        "IsAmbiguous": false,
+                                        "IsVote": true,
+                                        "OutstackConditionIds": [
+                                            1
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "OutstackConditionIds": []
+                    }
+                ]
+            },
+            "Modified": {
+                "PrecinctPortionId": 214,
+                "BallotTypeId": 102,
+                "IsCurrent": true,
+                "Cards": [
+                    {
+                        "Id": 23456,
+                        "KeyInId": 23456,
+                        "PaperIndex": 1,
+                        "Contests": [
+                            {
+                                "Id": 1,
+                                "ManifestationId": 234567,
+                                "Undervotes": 1,
+                                "Overvotes": 0,
+                                "OutstackConditionIds": [
+                                    4,
+                                    6
+                                ],
+                                "Marks": []
+                            }
+                        ],
+                        "OutstackConditionIds": []
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/shangrla/shangrla/tests/Data/Dominion_CVRs/test_5.2.18.2.Dominion.json
+++ b/shangrla/shangrla/tests/Data/Dominion_CVRs/test_5.2.18.2.Dominion.json
@@ -1,0 +1,123 @@
+{
+    "Version": "5.2.18.2",
+    "ElectionId": "GENERAL ELECTION",
+    "Sessions": [
+        {
+            "TabulatorId": 60001,
+            "BatchId": 1,
+            "RecordId": 1,
+            "CountingGroupId": 2,
+            "ImageMask": "E:\\NAS\\GENERAL ELECTION\\Results\\Tabulator60001\\Batch001\\Images\\60001_00001_000001*.*",
+            "Original": {
+                "PrecinctPortionId": 123,
+                "BallotTypeId": 2,
+                "IsCurrent": true,
+                "Contests": [
+                    {
+                        "Id": 111,
+                        "Marks": [
+                            {
+                                "CandidateId": 6,
+                                "PartyId": 0,
+                                "Rank": 1,
+                                "MarkDensity": 85,
+                                "IsAmbiguous": false,
+                                "IsVote": true
+                            },
+                            {
+                                "CandidateId": 1,
+                                "PartyId": 0,
+                                "Rank": 2,
+                                "MarkDensity": 94,
+                                "IsAmbiguous": false,
+                                "IsVote": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "TabulatorId": 60009,
+            "BatchId": 3,
+            "RecordId": 21,
+            "CountingGroupId": 2,
+            "ImageMask": "E:\\NAS\\GENERAL ELECTION\\Results\\Tabulator60009\\Batch003\\Images\\60009_00003_000021*.*",
+            "Original": {
+                "PrecinctPortionId": 456,
+                "BallotTypeId": 2,
+                "IsCurrent": false,
+                "Contests": [
+                    {
+                        "Id": 111,
+                        "Marks": [
+                            {
+                                "CandidateId": 6,
+                                "PartyId": 0,
+                                "Rank": 1,
+                                "MarkDensity": 75,
+                                "IsAmbiguous": false,
+                                "IsVote": true
+                            }
+                        ]
+                    },
+                    {
+                        "Id": 122,
+                        "Marks": [
+                            {
+                                "CandidateId": 9,
+                                "PartyId": 0,
+                                "Rank": 1,
+                                "MarkDensity": 82,
+                                "IsAmbiguous": false,
+                                "IsVote": true
+                            },
+                            {
+                                "CandidateId": 48,
+                                "Rank": 2,
+                                "WriteinIndex": 0,
+                                "MarkDensity": 71,
+                                "WriteinDensity": 0,
+                                "IsAmbiguous": false,
+                                "IsVote": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            "Modified": {
+                "PrecinctPortionId": 456,
+                "BallotTypeId": 2,
+                "IsCurrent": true,
+                "Contests": [
+                    {
+                        "Id": 111,
+                        "Marks": [
+                            {
+                                "CandidateId": 6,
+                                "PartyId": 0,
+                                "Rank": 1,
+                                "MarkDensity": 75,
+                                "IsAmbiguous": false,
+                                "IsVote": true
+                            }
+                        ]
+                    },
+                    {
+                        "Id": 122,
+                        "Marks": [
+                            {
+                                "CandidateId": 9,
+                                "PartyId": 0,
+                                "Rank": 1,
+                                "MarkDensity": 82,
+                                "IsAmbiguous": false,
+                                "IsVote": true
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/shangrla/shangrla/tests/test_Dominion.py
+++ b/shangrla/shangrla/tests/test_Dominion.py
@@ -24,6 +24,136 @@ from shangrla.Hart import Hart
 ##########################################################################################
 
 class TestDominion:
+    def test_read_cvrs_old_format(self):
+        """
+        Test reading the older Dominion CVR format
+        """
+        cvr_list = Dominion.read_cvrs(
+            "shangrla/shangrla/tests/Data/Dominion_CVRs/test_5.2.18.2.Dominion.json"
+        )
+        assert len(cvr_list) == 2
+        cvr_1, cvr_2 = cvr_list
+        assert cvr_1.id == "60001_1_1"
+        assert list(cvr_1.votes.keys()) == ["111"]
+        assert cvr_1.votes["111"] == {"6": 1, "1": 2}
+        assert cvr_1.get_vote_for("111", "6")
+        assert cvr_1.get_vote_for("111", "1")
+        assert cvr_1.get_vote_for("111", "999") is False
+        assert cvr_2.id == "60009_3_21"
+        assert list(cvr_2.votes.keys()) == ["111", "122"]
+        assert cvr_2.votes["111"] == {"6": 1}
+        assert cvr_2.votes["122"] == {"9": 1, "48": 2}
+        assert cvr_2.get_vote_for("111", "6")
+        assert cvr_2.get_vote_for("111", "1") is False
+        assert cvr_2.get_vote_for("122", "9")
+        assert cvr_2.get_vote_for("122", "48")
+        assert cvr_2.get_vote_for("122", "999") is False
+
+    def test_read_cvrs_old_format_adjudicated(self):
+        """
+        Tests using the "Modified" (adjudicated) data from the CVR (if present) over the "Original"
+        Ingests the older Dominion CVR format
+        """
+        cvr_list = Dominion.read_cvrs(
+            "shangrla/shangrla/tests/Data/Dominion_CVRs/test_5.2.18.2.Dominion.json",
+            use_adjudicated=True,
+        )
+        assert len(cvr_list) == 2
+        cvr_1, cvr_2 = cvr_list
+        assert cvr_1.id == "60001_1_1"
+        assert list(cvr_1.votes.keys()) == ["111"]
+        assert cvr_1.votes["111"] == {"6": 1, "1": 2}
+        assert cvr_1.get_vote_for("111", "6")
+        assert cvr_1.get_vote_for("111", "1")
+        assert cvr_1.get_vote_for("111", "999") is False
+        assert cvr_2.id == "60009_3_21"
+        assert list(cvr_2.votes.keys()) == ["111", "122"]
+        assert cvr_2.votes["111"] == {"6": 1}
+        assert cvr_2.votes["122"] == {"9": 1}
+        assert cvr_2.get_vote_for("111", "6")
+        assert cvr_2.get_vote_for("111", "1") is False
+        assert cvr_2.get_vote_for("122", "9")
+        assert cvr_2.get_vote_for("122", "48") is False
+        assert cvr_2.get_vote_for("122", "999") is False
+
+    def test_read_cvrs_new_format(self):
+        """
+        Test reading the newer Dominion CVR format
+        """
+        cvr_list = Dominion.read_cvrs(
+            "shangrla/shangrla/tests/Data/Dominion_CVRs/test_5.10.50.85.Dominion.json"
+        )
+        assert len(cvr_list) == 2
+        cvr_1, cvr_2 = cvr_list
+        assert cvr_1.id == "1_2_13"
+        assert list(cvr_1.votes.keys()) == ["1"]
+        assert cvr_1.votes["1"] == {"5": 1}
+        assert cvr_1.get_vote_for("1", "5")
+        assert cvr_1.get_vote_for("1", "999") is False
+        assert cvr_2.id == "1_5_119"
+        assert list(cvr_2.votes.keys()) == ["1"]
+        assert cvr_2.votes["1"] == {"6": 1}
+        assert cvr_2.get_vote_for("1", "6")
+        assert cvr_2.get_vote_for("1", "999") is False
+
+    def test_read_cvrs_new_format_adjudicated(self):
+        """
+        Tests using the "Modified" (adjudicated) data from the CVR (if present) over the "Original"
+        Ingests the newer Dominion CVR format
+        """
+        cvr_list = Dominion.read_cvrs(
+            "shangrla/shangrla/tests/Data/Dominion_CVRs/test_5.10.50.85.Dominion.json",
+            use_adjudicated=True,
+        )
+        assert len(cvr_list) == 2
+        cvr_1, cvr_2 = cvr_list
+        assert cvr_1.id == "1_2_13"
+        assert list(cvr_1.votes.keys()) == ["1"]
+        assert cvr_1.votes["1"] == {"5": 1}
+        assert cvr_1.get_vote_for("1", "5")
+        assert cvr_1.get_vote_for("1", "999") is False
+        assert cvr_2.id == "1_5_119"
+        assert list(cvr_2.votes.keys()) == ["1"]
+        assert cvr_2.votes["1"] == {}
+        assert cvr_2.get_vote_for("1", "6") is False
+        assert cvr_2.get_vote_for("1", "999") is False
+
+    def test_read_cvrs_new_format_vbm_only(self):
+        """
+        Test reading the newer Dominion CVR format, selecting VBM results only
+        """
+        cvr_list = Dominion.read_cvrs(
+            "shangrla/shangrla/tests/Data/Dominion_CVRs/test_5.10.50.85.Dominion.json",
+            include_groups=(2,),
+        )
+        assert len(cvr_list) == 1
+        cvr_2 = cvr_list[0]
+        assert cvr_2.id == "1_5_119"
+        assert list(cvr_2.votes.keys()) == ["1"]
+        assert cvr_2.votes["1"] == {"6": 1}
+        assert cvr_2.get_vote_for("1", "6")
+        assert cvr_2.get_vote_for("1", "999") is False
+
+    def test_read_cvrs_directory(self):
+        """
+        Tests the convenience function for reading all CVRs from a given directory
+        """
+        cvr_list = Dominion.read_cvrs_directory(
+            "shangrla/shangrla/tests/Data/Dominion_CVRs/CVR_Export",
+        )
+        assert len(cvr_list) == 2
+        cvr_1, cvr_2 = cvr_list
+        assert cvr_1.id == "1_2_13"
+        assert list(cvr_1.votes.keys()) == ["1"]
+        assert cvr_1.votes["1"] == {"5": 1}
+        assert cvr_1.get_vote_for("1", "5")
+        assert cvr_1.get_vote_for("1", "999") is False
+        assert cvr_2.id == "1_5_119"
+        assert list(cvr_2.votes.keys()) == ["1"]
+        assert cvr_2.votes["1"] == {"6": 1}
+        assert cvr_2.get_vote_for("1", "6")
+        assert cvr_2.get_vote_for("1", "999") is False
+
     def test_sample_from_manifest(self):
         """
         Test the card lookup function


### PR DESCRIPTION
- support newer Dominion CVR format transparently (code is backwards-compatible with older format)
- support selecting adjudicated over original marks when reading Dominion CVRs
- select by group (e.g. VBM only)
- add Dominion.read_cvrs_directory() convenience class method
- add tests for all new features
