### PR TITLE
Fix implementation of Welford's algorithm

### DIFF
--- a/shangrla/core/NonnegMean.py
+++ b/shangrla/core/NonnegMean.py
@@ -7,7 +7,7 @@ import warnings
 
 def welford_mean_var(x: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """
-    Welford's algorithm for running mean and running sd
+    Welford's algorithm for running mean and variance
     """
     m = [x[0]]
     v = [0]
@@ -15,7 +15,7 @@ def welford_mean_var(x: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         m.append(m[-1] + (xi - m[-1]) / (i + 2))
         v.append(v[-1] + (xi - m[-2]) * (xi - m[-1]))
     v = v / np.arange(1, len(x) + 1)
-    return m, v
+    return np.array(m), v
 
 
 class NonnegMean:

--- a/tests/core/test_NonnegMean.py
+++ b/tests/core/test_NonnegMean.py
@@ -178,7 +178,7 @@ class TestNonnegMean:
         c_g_0 = 0.5
         c_g_m = 0.99
         c_g_g = 0
-        N = np.infty
+        N = np.inf
         u = 1
         n=10
         # test for sampling with replacement, constant c
@@ -217,7 +217,7 @@ class TestNonnegMean:
                 np.testing.assert_almost_equal(lam_0, lam_t)
 
     def test_betting_mart(self):
-        N = np.infty
+        N = np.inf
         n = 20
         t = 0.5
         u = 1


### PR DESCRIPTION
This PR aims to resolve issue #88.

I have written a new function `welford_mean_var(x: np.ndarray) -> tuple[np.ndarray, np.ndarray]` which calculates the running mean and variance of the sample. It turns out the original error was very slight, just an `(i + 1)` where there should have been an `(i + 2)`.

Out of curiosity, where does this parameter `f` for `shrink_trunc` come from? I don't see it described at all in your original paper for ALPHA.