### PR TITLE
Dominion

### DIFF
--- a/examples/ONEAudit-demo.ipynb
+++ b/examples/ONEAudit-demo.ipynb
@@ -90,6 +90,7 @@
     "+ Read manual interpretations of the cards (MVRs)\n",
     "+ Calculate attained risk for each assorter\n",
     "    - Use ~2EZ to deal with phantom CVRs or cards; the treatment depends on whether `use_style == True`\n",
+    "    - If a sampled card cannot be found/retrieved, use the phantom-to-zombie transformation for it\n",
     "    - Use the pooled assorter means for cards in pooled batches\n",
     "+ Report\n",
     "+ Estimate incremental sample size if any assorter nulls have not been rejected\n",
@@ -1006,7 +1007,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Read the audited sample data"
+    "# Read the audited sample data.\n",
+    "\n",
+    "## Any ballot that cannot be retrieved should be marked as a \"zombie\" (treated in the least favorable way for every contest it might contain)."
    ]
   },
   {

--- a/shangrla/core/Audit.py
+++ b/shangrla/core/Audit.py
@@ -1931,7 +1931,8 @@ class Assertion:
     @classmethod
     def make_supermajority_assertion(
         cls,
-        contest,
+        contest: object=None,
+        share_to_win: float = 1/2,
         winner: str = None,
         loser: list = None,
         test: callable = None,
@@ -1962,12 +1963,12 @@ class Assertion:
         -----------
         contest:
             contest object instance to which the assertion applies
+        share_to_win: float
+            fraction of the valid votes the winner must get to win
         winner:
             identifier of winning candidate
         loser: list
             list of identifiers of losing candidate(s)
-        share_to_win: float
-            fraction of the valid votes the winner must get to win
         test: instance of NonnegMean
             risk function for the contest
         estim: an estimation method of NonnegMean
@@ -2218,7 +2219,7 @@ class Assertion:
            `assertion.contest.audit_type==Audit.AUDIT_TYPE.POLLING`
            or `assertion.contest.audit_type in [Audit.AUDIT_TYPE.CARD_COMPARISON, Audit.AUDIT_TYPE.ONEAUDIT]`
         """
-        min_margin = np.infty
+        min_margin = np.inf
         for c, con in contests.items():
             con.margins = {}
             for a, asn in con.assertions.items():

--- a/shangrla/formats/Dominion.py
+++ b/shangrla/formats/Dominion.py
@@ -97,6 +97,12 @@ class Dominion:
            "Marks" as the container for votes
            "Rank" as the rank
 
+        **WARNING**
+        Uses San Francisco's rules for validity of an IRV ballot; in particular, if a CVR gives
+        a candidate more than one rank, the vote is considered valid and the lowest rank is used.
+        
+        **WARNING This may break some scoring rules!**
+
         Parameters:
         -----------
         cvr_file: string
@@ -154,9 +160,19 @@ class Dominion:
                 for con in _selector:
                     contest_votes = {}
                     for mark in con["Marks"]:
-                        if (mark["IsVote"] or not enforce_rules):
-                            contest_votes[str(mark["CandidateId"])] =  mark["Rank"]
-                    votes[str(con["Id"])] = contest_votes
+                        if mark["IsVote"] or not enforce_rules:
+                            if str(mark["CandidateId"]) in contest_votes.keys():
+                            # replace existing vote/rank if the new rank is lower but still a vote, not 0 or False
+                            # This may break some scoring rules other than IRV, and might not be what local rules
+                            # require. This logic branch matches San Francisco's rules.
+                                if bool(mark["Rank"]):
+                                    contest_votes[str(mark["CandidateId"])] = (
+                                        min(int(contest_votes[str(mark["CandidateId"])]), int(mark["Rank"]))
+                                        if bool(contest_votes[str(mark["CandidateId"])])
+                                        else int(mark["Rank"]
+                            else:
+                                contest_votes[str(mark["CandidateId"])] = mark["Rank"]
+                     votes[str(con["Id"])] = contest_votes
             # If RecordId is obfuscated, extract it from the ImageMask
             record_id = c["RecordId"]
             if record_id == "X":

--- a/shangrla/formats/Dominion.py
+++ b/shangrla/formats/Dominion.py
@@ -154,9 +154,8 @@ class Dominion:
                 for con in _selector:
                     contest_votes = {}
                     for mark in con["Marks"]:
-                        contest_votes[str(mark["CandidateId"])] = (
-                            mark["Rank"] if (mark["IsVote"] or not enforce_rules) else 0
-                        )
+                        if (mark["IsVote"] or not enforce_rules):
+                            contest_votes[str(mark["CandidateId"])] =  mark["Rank"]
                     votes[str(con["Id"])] = contest_votes
             # If RecordId is obfuscated, extract it from the ImageMask
             record_id = c["RecordId"]

--- a/shangrla/formats/Dominion.py
+++ b/shangrla/formats/Dominion.py
@@ -173,7 +173,7 @@ class Dominion:
                                     )
                             else:
                                 contest_votes[str(mark["CandidateId"])] = mark["Rank"]
-                     votes[str(con["Id"])] = contest_votes
+                    votes[str(con["Id"])] = contest_votes
             # If RecordId is obfuscated, extract it from the ImageMask
             record_id = c["RecordId"]
             if record_id == "X":

--- a/shangrla/formats/Dominion.py
+++ b/shangrla/formats/Dominion.py
@@ -169,7 +169,7 @@ class Dominion:
                                     contest_votes[str(mark["CandidateId"])] = (
                                         min(int(contest_votes[str(mark["CandidateId"])]), int(mark["Rank"]))
                                         if bool(contest_votes[str(mark["CandidateId"])])
-                                        else int(mark["Rank"]
+                                        else int(mark["Rank"])
                             else:
                                 contest_votes[str(mark["CandidateId"])] = mark["Rank"]
                      votes[str(con["Id"])] = contest_votes

--- a/shangrla/formats/Dominion.py
+++ b/shangrla/formats/Dominion.py
@@ -170,6 +170,7 @@ class Dominion:
                                         min(int(contest_votes[str(mark["CandidateId"])]), int(mark["Rank"]))
                                         if bool(contest_votes[str(mark["CandidateId"])])
                                         else int(mark["Rank"])
+                                    )
                             else:
                                 contest_votes[str(mark["CandidateId"])] = mark["Rank"]
                      votes[str(con["Id"])] = contest_votes

--- a/tests/formats/test_Dominion.py
+++ b/tests/formats/test_Dominion.py
@@ -56,12 +56,12 @@ class TestDominion:
         assert not cvr_1.pool, f"{cvr_1.pool=}"
         assert list(cvr_1.votes.keys()) == ["111"]
         # Reading Dominion CVRs now takes "IsVote" and "Modified" values into account,
-        # so {"6": 1, "1": 2} now becomes {"6": 1, "1": 0} (vote for candidate 1 in this
+        # so {"6": 1, "1": 2} now becomes {"6": 1} (vote for candidate 1 in this
         # testcase is marked "IsVote": false).  For the same reason, the call to
-        # get_vote_for("111", "1") is now 0.
-        assert cvr_1.votes["111"] == {"6": 1, "1": 0}
+        # get_vote_for("111", "1") is now False.
+        assert cvr_1.votes["111"] == {"6": 1}
         assert cvr_1.get_vote_for("111", "6")
-        assert cvr_1.get_vote_for("111", "1") == 0
+        assert cvr_1.get_vote_for("111", "1") is False
         assert cvr_1.get_vote_for("111", "999") is False
         assert cvr_2.id == "60009_3_21"
         assert cvr_2.tally_pool == "60009_3"


### PR DESCRIPTION
Update formats.Dominion.read_cvrs() to handle mis-marked RCV ballots according to local San Francisco rules, including keeping only the lowest rank a CVR assigns to a candidate if more than one rank is given. Also minor bug fixes.